### PR TITLE
Hide splitters. Update version.

### DIFF
--- a/Manifest.json
+++ b/Manifest.json
@@ -11,7 +11,7 @@
         "email": "tobi@itis.swiss"
       }
     ],
-    "version": "0.4.5"
+    "version": "0.4.6"
   },
   "provides": {
     "namespace": "osparc.theme",

--- a/source/class/osparc/theme/osparcdark/Appearance.js
+++ b/source/class/osparc/theme/osparcdark/Appearance.js
@@ -802,7 +802,10 @@ qx.Theme.define("osparc.theme.osparcdark.Appearance", {
     "splitpane/splitter":
       {
         style: function(states) {
-          return {backgroundColor: "light-background"};
+          return {
+            backgroundColor: "light-background",
+            visible: false
+          };
         }
       },
 


### PR DESCRIPTION
Now the visibility of the splitter is a themeable property so we can put it in the application theme.